### PR TITLE
modification titres pour les offres fs/fi

### DIFF
--- a/views/partials/fi/fi-offres.ejs
+++ b/views/partials/fi/fi-offres.ejs
@@ -1,13 +1,12 @@
-<h2 id="offre-dnum" class="fr-mt-8w">Offres disponibles</h2>
-<h3 class="fr-h6">Les services listés ci-dessous proposent AgentConnect&nbsp;:</h3>
+<h2 id="offre-dnum" class="fr-mt-8w">Liste des services proposant AgentConnect</h2>
 <div class="fr-grid-row fr-grid-row--gutters fr-mb-3w">
     <% offres_fi.forEach(function(offre){ %>
         <%- include('./fi-offre.ejs', {offre}); %>
-    <% }); %>
+            <% }); %>
 </div>
 <h3 class="fr-h5">Les services en cours de test&nbsp;:</h3>
 <ul>
     <% offres_fi_test.forEach(function(offre_test){ %>
         <%- include('./fi-offre-test.ejs', {offre_test}); %>
-    <% }); %>
+            <% }); %>
 </ul>

--- a/views/partials/fs/fs-offre.ejs
+++ b/views/partials/fs/fs-offre.ejs
@@ -1,6 +1,5 @@
-<div class="fr-table">
+<div class="fr-table fr-pt-0">
     <table>
-        <caption class="fr-h6">Ministères et administrations pouvant se connecter via AgentConnect :</caption>
         <thead>
             <tr>
                 <th scope="col">Organisation</th>
@@ -14,7 +13,7 @@
             </tr>
             <tr>
                 <td>INRAE</td>
-                <td>-</td>  
+                <td>-</td>
             </tr>
             <tr>
                 <td>Ministère de l’Économie, des Finances et de la Souveraineté industrielle et numérique</td>
@@ -28,7 +27,7 @@
                         <li>Direction générale des Finances publiques (DGFIP)</li>
                         <li>Institut National de la Statistique et des Études Économiques (INSEE)</li>
                     </ul>
-                    
+
                 </td>
             </tr>
             <tr>

--- a/views/partials/fs/fs-offres.ejs
+++ b/views/partials/fs/fs-offres.ejs
@@ -1,2 +1,2 @@
-<h2 id="offre-ep" class="fr-mt-6w">Offres disponibles</h2>
+<h2 id="offre-ep" class="fr-mt-6w">Liste des administrations pouvant utiliser AgentConnect</h2>
 <%- include('../fs/fs-offre.ejs'); %>


### PR DESCRIPTION
## 🎯 Objectif

Amélioration de l'information en changeant les titres sur les offres des FS et FI.