### PR TITLE
RD: replace gouvernement.fr by info.gouv.fr

### DIFF
--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -12,7 +12,7 @@
             <a class="fr-footer__content-link" target="_blank" href="https://legifrance.gouv.fr">legifrance.gouv.fr</a>
           </li>
           <li class="fr-footer__content-item">
-            <a class="fr-footer__content-link" target="_blank" href="https://gouvernement.fr">gouvernement.fr</a>
+            <a class="fr-footer__content-link" target="_blank" href="https://info.gouv.fr">info.gouv.fr</a>
           </li>
           <li class="fr-footer__content-item">
             <a class="fr-footer__content-link" target="_blank" href="https://service-public.fr">service-public.fr</a>


### PR DESCRIPTION
The address of the official government site has changed and the SIG has asked us to update the footer links.